### PR TITLE
AN-1 - bugfix

### DIFF
--- a/app/src/main/java/pl/kodujdlapolski/na4lapy/model/Animal.java
+++ b/app/src/main/java/pl/kodujdlapolski/na4lapy/model/Animal.java
@@ -17,6 +17,7 @@ package pl.kodujdlapolski.na4lapy.model;
 
 import com.annimon.stream.Optional;
 import com.annimon.stream.Stream;
+import com.google.gson.annotations.SerializedName;
 
 import org.joda.time.LocalDate;
 
@@ -38,12 +39,15 @@ import pl.kodujdlapolski.na4lapy.model.type.Vaccination;
 public class Animal implements Serializable {
 
     private Long id;
-    private Long shelterid;
+    @SerializedName("shelterid")
+    private Long shelterId;
     private String name;
     private String race;
     private String description;
     private String chipId;
+    @SerializedName("birthdate")
     private LocalDate birthDate;
+    @SerializedName("admittancedate")
     private LocalDate admittanceDate;
     private Sterilization sterilization;
     private Species species;

--- a/app/src/main/java/pl/kodujdlapolski/na4lapy/service/api/LocalDateDeserializer.java
+++ b/app/src/main/java/pl/kodujdlapolski/na4lapy/service/api/LocalDateDeserializer.java
@@ -15,6 +15,9 @@
  */
 package pl.kodujdlapolski.na4lapy.service.api;
 
+import android.text.TextUtils;
+import android.util.Log;
+
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
@@ -28,6 +31,15 @@ import java.lang.reflect.Type;
 public class LocalDateDeserializer implements JsonDeserializer<LocalDate> {
     @Override
     public LocalDate deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
-        return DateTimeFormat.forPattern("yyyy-MM-dd").parseLocalDate(json.getAsString());
+        try {
+            String value = json.getAsString();
+            if (TextUtils.isEmpty(value)) {
+                return null;
+            }
+            return DateTimeFormat.forPattern("yyyy-MM-dd").parseLocalDate(value);
+        } catch(Exception e) {
+            Log.e("LocalDateDeserializer", e.getMessage(), e);
+        }
+        return null;
     }
 }

--- a/app/src/main/java/pl/kodujdlapolski/na4lapy/ui/browse/AbstractBrowseViewHolder.java
+++ b/app/src/main/java/pl/kodujdlapolski/na4lapy/ui/browse/AbstractBrowseViewHolder.java
@@ -23,14 +23,12 @@ import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import com.squareup.picasso.MemoryPolicy;
 import com.squareup.picasso.Picasso;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import pl.kodujdlapolski.na4lapy.R;
 import pl.kodujdlapolski.na4lapy.model.Animal;
-import pl.kodujdlapolski.na4lapy.model.Photo;
 import pl.kodujdlapolski.na4lapy.service.user.UserService;
 import pl.kodujdlapolski.na4lapy.ui.details.DetailsActivity;
 

--- a/app/src/main/java/pl/kodujdlapolski/na4lapy/ui/details/ContentDetailsView.java
+++ b/app/src/main/java/pl/kodujdlapolski/na4lapy/ui/details/ContentDetailsView.java
@@ -135,8 +135,8 @@ public class ContentDetailsView {
     }
 
     private void initMoreInfoTable() {
-        if (animal.getShelterid() != null)
-            setShelterInfo(animal.getShelterid());
+        if (animal.getShelterId() != null)
+            setShelterInfo(animal.getShelterId());
 
         if (animal.getAdmittanceDate() != null) {
             infoAdmittanceDate.setText(getShortDateTextFrom(animal.getAdmittanceDate()));

--- a/app/src/main/java/pl/kodujdlapolski/na4lapy/ui/details/DetailsActivity.java
+++ b/app/src/main/java/pl/kodujdlapolski/na4lapy/ui/details/DetailsActivity.java
@@ -32,7 +32,6 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.ImageView;
 
-import com.squareup.picasso.MemoryPolicy;
 import com.squareup.picasso.Picasso;
 
 import org.joda.time.LocalDate;
@@ -49,7 +48,6 @@ import jp.wasabeef.picasso.transformations.CropCircleTransformation;
 import pl.kodujdlapolski.na4lapy.Na4LapyApp;
 import pl.kodujdlapolski.na4lapy.R;
 import pl.kodujdlapolski.na4lapy.model.Animal;
-import pl.kodujdlapolski.na4lapy.model.Photo;
 import pl.kodujdlapolski.na4lapy.service.repository.RepositoryService;
 import pl.kodujdlapolski.na4lapy.service.system.SystemService;
 import pl.kodujdlapolski.na4lapy.service.user.UserService;


### PR DESCRIPTION
* w szczegolach zwierzecia poprawiono: jesli rasa albo numer chipu sa pustym stringiem, to rowniez nie zostana wyswietlone
* poprawiono mapowanie danych pomiedzy api a aplikacja dla wieku zwierzecia i daty przystapienia
* poprawiono deserializera dat - jest odporny na pustego stringa oraz zly format daty